### PR TITLE
chore: update to livekit-agents>=1.5.17

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,25 +1,24 @@
 import logging
 from collections.abc import AsyncIterable
+from typing import Any, Coroutine, Union
 
 from dotenv import load_dotenv
-
 from livekit import rtc
 from livekit.agents import (
     Agent,
     AgentSession,
+    ConversationItemAddedEvent,
     JobContext,
-    JobProcess,
-    MetricsCollectedEvent,
     ModelSettings,
     RoomInputOptions,
     RoomOutputOptions,
     RunContext,
     WorkerOptions,
     cli,
-    metrics,
 )
-from livekit.agents.llm import function_tool
-from livekit.plugins import cartesia, openai, silero
+from livekit.agents.beta.tools.end_call import EndCallTool
+from livekit.agents.llm import ChatMessage, function_tool
+from livekit.plugins import cartesia, openai
 
 # uncomment to enable Krisp background voice/noise cancellation
 # from livekit.plugins import noise_cancellation
@@ -32,21 +31,29 @@ load_dotenv()
 class CartesiaAgent(Agent):
     def __init__(self) -> None:
         super().__init__(
-            instructions="Your name is Kelly. You would interact with users via voice."
-            "with that in mind keep your responses concise and to the point."
-            "do not use emojis, asterisks, markdown, or other special characters in your responses."
-            "You are curious and friendly, and have a sense of humor."
-            "you will speak english to the user",
+            instructions="your name is Katie."
+            " you would interact with users via voice."
+            " with that in mind, keep your responses concise and to the point."
+            " do not use emojis, asterisks, markdown, or other special characters in your responses."
+            " you are curious and friendly, and have a sense of humor."
+            " you will speak english to the user.",
+            # you can pass tools to the LLM in the list here
+            # or by decorating CartesiaAgent methods with @function_tool
+            tools=[EndCallTool()],
         )
 
-    async def on_enter(self):
+    async def on_enter(self) -> None:
         # when the agent is added to the session, it'll generate a reply
         # according to its instructions
         self.session.generate_reply()
 
-    async def tts_node(
+    def tts_node(
         self, text: AsyncIterable[str], model_settings: ModelSettings
-    ) -> AsyncIterable[rtc.AudioFrame]:
+    ) -> Union[
+        AsyncIterable[rtc.AudioFrame],
+        Coroutine[Any, Any, AsyncIterable[rtc.AudioFrame]],
+        Coroutine[Any, Any, None],
+    ]:
         # Markdown and emoji filters are enabled in `Agent.tts_node`, markdown symbols
         # and emojis will be removed from the text sent to the TTS model
 
@@ -55,65 +62,78 @@ class CartesiaAgent(Agent):
 
         return super().tts_node(text, model_settings)
 
-    # all functions annotated with @function_tool will be passed to the LLM when this
-    # agent is active
+    # all functions decorated with @function_tool will be passed to the LLM
     @function_tool
     async def lookup_weather(
-        self, context: RunContext, location: str, latitude: str, longitude: str
-    ):
-        """Called when the user asks for weather related information.
-        Ensure the user's location (city or region) is provided.
-        When given a location, please estimate the latitude and longitude of the location and
-        do not ask the user for them.
+        self,
+        context: RunContext,
+        location: str,
+    ) -> str:
+        """Lookup weather at a location.
 
         Args:
-            location: The location they are asking for
-            latitude: The latitude of the location, do not ask user for it
-            longitude: The longitude of the location, do not ask user for it
+            location (str): The location to lookup weather for (city or region).
         """
 
-        logger.info(f"Looking up weather for {location}")
+        logger.info(f"Function called: lookup_weather({location=})")
 
+        # mock implementation
         return "sunny with a temperature of 70 degrees."
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-async def entrypoint(ctx: JobContext):
+async def entrypoint(ctx: JobContext) -> None:
     # each log entry will include these fields
     ctx.log_context_fields = {
         "room": ctx.room.name,
     }
     # For more information, check out the Cartesia Plugin for LiveKit:
     # https://docs.livekit.io/agents/integrations/tts/cartesia/
-    session = AgentSession(
-        vad=ctx.proc.userdata["vad"],
-        # any combination of STT, LLM, TTS, or realtime API can be used
-        llm=openai.LLM(model="gpt-4o-mini"),
-        stt=cartesia.STT(),
-        tts=cartesia.TTS(model="sonic-3"),  # specify the model and voice params here
-        # allow the LLM to generate a response while waiting for the end of turn
-        preemptive_generation=True,
-        # sometimes background noise can interrupt the agent session, these are considered false positive interruptions
-        # when it's detected, you may resume the agent's speech
-        resume_false_interruption=True,
-        false_interruption_timeout=1.0,
-        min_interruption_duration=0.2,  # with false interruption resume, interruption can be more sensitive
+    session: AgentSession = AgentSession(
+        # any combination of STT, LLM, TTS can be used
+        stt=cartesia.STT(
+            language="en"
+            # model="..."
+        ),
+        llm=openai.LLM(
+            # model="..."
+        ),
+        tts=cartesia.TTS(
+            language="en"
+            # model="..."
+            # voice="..."
+        ),
+        turn_handling={
+            # turn_detection is how your agent decides when the user is done speaking
+            # "stt" is supported with cartesia.STT(model="ink-2") and later
+            "turn_detection": "stt",
+            # preemptive_generation allows the LLM to generate a response
+            # while waiting for the end of turn
+            # supported with cartesia.STT(model="ink-2") and later
+            "preemptive_generation": {
+                "enabled": True,
+            },
+            "interruption": {
+                "enabled": True,
+                # sometimes background noise can interrupt the agent session
+                # these are considered false positive interruptions
+                # when it's detected, you may resume the agent's speech
+                "resume_false_interruption": True,
+                "false_interruption_timeout": 1.0,
+                # lower min_duration makes your agent more sensitive to interruptions
+                "min_duration": 0.2,
+            },
+        },
     )
 
-    # log metrics as they are emitted, and total usage after session is over
-    usage_collector = metrics.UsageCollector()
+    # log per-turn latency metrics as conversation items are added
+    @session.on("conversation_item_added")
+    def _on_conversation_item_added(ev: ConversationItemAddedEvent):
+        if isinstance(ev.item, ChatMessage) and ev.item.metrics:
+            logger.info(f"Metrics: {ev.item.metrics}")
 
-    @session.on("metrics_collected")
-    def _on_metrics_collected(ev: MetricsCollectedEvent):
-        metrics.log_metrics(ev.metrics)
-        usage_collector.collect(ev.metrics)
-
+    # log total usage after the session is over
     async def log_usage():
-        summary = usage_collector.get_summary()
-        logger.info(f"Usage: {summary}")
+        logger.info(f"Usage: {session.usage}")
 
     # shutdown callbacks are triggered when the session is over
     ctx.add_shutdown_callback(log_usage)
@@ -130,4 +150,4 @@ async def entrypoint(ctx: JobContext):
 
 
 if __name__ == "__main__":
-    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm))
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-livekit-agents[openai,silero,cartesia,turn-detector]~=1.0
+livekit-agents[openai,cartesia,turn-detector]>=1.5.17,<2
 python-dotenv


### PR DESCRIPTION
Update to `livekit-agents>=1.5.17` to get Ink 2 support

Also:

1. Moves off of deprecated kwargs and `metrics_collected`
2. Switches from VAD to STT for turn detection
3. Change tools
4. Fixes types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turn detection moves from VAD to STT and session/interruption configuration is restructured, which can change when the agent speaks or stops; dependency floor jump may affect runtime behavior.
> 
> **Overview**
> Bumps **`livekit-agents`** to **>=1.5.17** (drops **silero** from extras) and aligns the sample voice agent with the newer SDK APIs.
> 
> **Session & turn handling:** Removes Silero **VAD** prewarm and per-session `vad=` wiring. Replaces flat kwargs (`preemptive_generation`, `resume_false_interruption`, etc.) with a **`turn_handling`** dict using **STT-based** `turn_detection`, nested preemptive generation, and interruption settings. STT/TTS default to **`language="en"`** with model/voice left as commented placeholders.
> 
> **Observability:** Drops **`metrics_collected`** / **`UsageCollector`**; logs per-turn metrics on **`conversation_item_added`** and logs **`session.usage`** at shutdown.
> 
> **Agent behavior:** Registers **`EndCallTool`** on the agent; simplifies **`lookup_weather`** to a single `location` arg (mock response). Persona/instruction text is lightly edited (Katie). **`tts_node`** is sync with an expanded return type union.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46cc1c8935daa9a4b15c8a9e32424027340d9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->